### PR TITLE
fix pip install

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,15 @@
 
 ## 安装
 
+源码安装
+
 ```bash
 pdm install
+```
+仓库安装
+
+```bash
+pip install git+https://github.com/gouzil/autoTable
 ```
 
 ## 使用方式

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,10 @@ license = { text = "MIT" }
 [project.scripts]
 autotable = "autotable.__main__:app"
 
+[tool.pdm.build]
+excludes = ["./**/.git"]
+includes = ["autotable"]
+
 [tool.pdm.scripts]
 test.cmd = "pytest ./tests --cov=autotable --cov-context=test"
 test.help = "Launch pytest"


### PR DESCRIPTION
修复 pip 安装后找不到 `autotable` 的问题
![390391710251796_ pic](https://github.com/gouzil/autoTable/assets/66515297/444c9fca-7f0d-4911-8bfa-9517ffc9280e)
