### PR TITLE
🐛 Fix: customized repo copies

### DIFF
--- a/autotable/command.py
+++ b/autotable/command.py
@@ -88,7 +88,14 @@ def update_content(
         # 修改表格内容, 根据多个repo的pr数据更新
         for pr_data_ in pr_data_list:
             # 更新pr数据
-            doc_table = update_pr_table(doc_table, title_re, pr_data_, pr_url_use_http_)
+            doc_table = update_pr_table(
+                doc_table,
+                title_re,
+                pr_data_,
+                False
+                if pr_data_[0].base.repo.full_name == tracker_issues_data.repo
+                else pr_url_use_http_,  # TODO:或许填写了自定义repo都应该使用http, 而不应该区分他是不是自己的repo
+            )
 
         # 评论更新
         doc_table = update_issue_table(doc_table, tracker_issues_data.issue_comments, enter_re)

--- a/autotable/command.py
+++ b/autotable/command.py
@@ -79,7 +79,10 @@ def update_content(
         # 如果repo地址不一致, 则重新获取pr列表
         if len(repo_list_) != 0:
             for repo_ in repo_list_:
-                pr_data_list.append(get_pr_list(tracker_issues_data.issue_create_time, title_re, repo_))
+                pull_request_list = get_pr_list(tracker_issues_data.issue_create_time, title_re, repo_)
+                # 去除pr列表为空的repo
+                if len(pull_request_list) != 0:  # type: ignore  # noqa: PGH003
+                    pr_data_list.append(pull_request_list)
             pr_url_use_http_ = True
 
         # 解析表格
@@ -87,6 +90,7 @@ def update_content(
 
         # 修改表格内容, 根据多个repo的pr数据更新
         for pr_data_ in pr_data_list:
+            assert len(pr_data_) != 0  # type: ignore  # noqa: PGH003
             # 更新pr数据
             doc_table = update_pr_table(
                 doc_table,

--- a/autotable/command.py
+++ b/autotable/command.py
@@ -70,7 +70,7 @@ def update_content(
         # 拆分markdown表格
         doc_table = analysis_table_content(issue_content, start_str, end_str)
         # 存储多个 repo 的 pr 数据
-        pr_data_list = [pr_data]
+        pr_data_list = [pr_data] if len(pr_data) != 0 else []  # type: ignore  # noqa: PGH003
         pr_url_use_http_ = False
 
         # 为当前表格单独解析 repo 地址

--- a/autotable/processor/github_prs.py
+++ b/autotable/processor/github_prs.py
@@ -69,7 +69,7 @@ def update_pr_table(table: Table, title_re: str, prs: PaginatedList[PullRequest]
             try:
                 pr_index_list: list[str] = titleBase(pr_indexs_text).distribution_parser().mate()
             except RuntimeError:
-                logger.error(f"{pr.number} Parsing title error, title: {pr.title}")
+                logger.debug(f"{pr.number} Parsing title error, title: {pr.title}")
                 continue
 
             # 如果与序号不匹配跳过


### PR DESCRIPTION
暂时修复了重复的情况，这里还没考虑好要怎么处理

```md
| 序号    | 文件    | API 数量 | 认领人 Github id             | PR 链接                                                                                                                              |
| ----- | -------- | ------ | -------------------- | ------------------------------------------------------------- |
| ✅A-1  | xxx/xxx/xxx     | 4      | ✅@gouzil          | https://github.com/gouzil/autoTable/pull/1<br/>#1<br/>          |

```