### PR TITLE
⚡ optimization(github_prs)： add globe reviews cache

### DIFF
--- a/autotable/constant.py
+++ b/autotable/constant.py
@@ -1,6 +1,17 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from github.PullRequest import PullRequest
+    from github.PullRequestReview import PullRequestReview
+
 APPNAME = "autotable"
 APPAUTHOR = "gouzil"
 CONSOLE_SUCCESSFUL = "✓"
 CONSOLE_ERROR = "✗"
+
+
+# processor/github_prs cache
+globe_error_prs: set[PullRequest] = set()
+globe_pr_reviews_cache: dict[int, list[PullRequestReview]] = {}

--- a/autotable/processor/github_prs.py
+++ b/autotable/processor/github_prs.py
@@ -9,6 +9,7 @@ from mistletoe.span_token import RawText, Strikethrough
 
 from autotable.autotable_type.autotable_type import StatusType
 from autotable.autotable_type.github_type import PrType, get_pr_type
+from autotable.constant import globe_error_prs, globe_pr_reviews_cache
 from autotable.processor.analysis import analysis_review, analysis_table_more_people
 from autotable.processor.github_title import titleBase
 from autotable.processor.utils import update_table_people
@@ -18,7 +19,6 @@ if TYPE_CHECKING:
     from github.PullRequest import PullRequest
     from github.PullRequestReview import PullRequestReview
 
-globe_error_prs: set[PullRequest] = set()
 
 """
 table.header:
@@ -84,9 +84,14 @@ def update_pr_table(table: Table, title_re: str, prs: PaginatedList[PullRequest]
 
             # 只有 reviews 的状态是 APPROVED 才是需要判断的
             pr_reviews: list[PullRequestReview] = []
-            for x in pr.get_reviews():
-                if x.state == "APPROVED":
-                    pr_reviews.append(x)
+            # 如果没有缓存则获取
+            if pr.number not in globe_pr_reviews_cache:
+                for x in pr.get_reviews():
+                    if x.state == "APPROVED":
+                        pr_reviews.append(x)
+                globe_pr_reviews_cache[pr.number] = pr_reviews
+            else:
+                pr_reviews = globe_pr_reviews_cache[pr.number]
 
             # 确认状态, 当前行的状态, 第一位永远为状态位
             status: StatusType = pr_match_status(pr_state, pr_reviews, index)

--- a/tests/test_github_title.py
+++ b/tests/test_github_title.py
@@ -36,10 +36,12 @@ def test_mix_title():
     title1 = "1, 2-4, 6"
     title2 = "1、 2-4、 6"
     title3 = "A-[48-52]"
+    title4 = "A-70][A-71"
 
     assert titleBase(title1).distribution_parser().mate() == ["1", "2", "3", "4", "6"]
     assert titleBase(title2).distribution_parser().mate() == ["1", "2", "3", "4", "6"]
     assert titleBase(title3).distribution_parser().mate() == ["A-48", "A-49", "A-50", "A-51", "A-52"]
+    assert titleBase(title4).distribution_parser().mate() == ["A-70", "A-71"]
 
 
 # 常见的几种错别字测试


### PR DESCRIPTION
## Performance optimization

对 reviews 增加 cache

ssl 连接数量 `833` -> `72`

运行时间 `2m 46.17s` -> `1m 27.31s`

表格数量: 144 行
pr 数量: 99 个

### old:
<img width="720" alt="截屏2024-06-24 下午5 34 52" src="https://github.com/gouzil/autoTable/assets/66515297/c1ef22dd-57e0-437f-a765-dda5720e469b">

![image](https://github.com/gouzil/autoTable/assets/66515297/aa8d34d1-68f6-43df-98ff-9bd3fed4ce52)

### now:
<img width="728" alt="截屏2024-06-24 下午5 35 03" src="https://github.com/gouzil/autoTable/assets/66515297/c8c0590d-79c0-45ce-9c19-3278f0e4d29e">

![image](https://github.com/gouzil/autoTable/assets/66515297/55dde01e-1164-4379-bc95-a770512379cd)
