### PR TITLE
♻️ reconfiguration:Add an intermediate presentation layer

### DIFF
--- a/autotable/api/prs.py
+++ b/autotable/api/prs.py
@@ -7,14 +7,15 @@ from github.PaginatedList import PaginatedList
 from github.PullRequest import PullRequest
 from loguru import logger
 
+from autotable.storage_model.pull_data import PullRequestData, PullReviewData
 from autotable.utils.fetcher import Fetcher
 
 
-def get_pr_list(start_time: datetime, title_re: str, repo: str = "") -> PaginatedList[PullRequest]:
+def get_pr_list(start_time: datetime, title_re: str, repo: str = "") -> list[PullRequestData]:
     """
     筛选出符合条件的pull request
     """
-    res: PaginatedList[PullRequest] = []
+    res: list[PullRequestData] = []
     data: PaginatedList[PullRequest] = Fetcher.get_pr_list(repo)
     for i in data:
         if not i.created_at > start_time:
@@ -22,7 +23,13 @@ def get_pr_list(start_time: datetime, title_re: str, repo: str = "") -> Paginate
             break
         # 如果正则匹配上了就会加入队列
         if re.search(title_re, i.title):
-            res.append(i)
+            reviews_ = i.get_reviews()
+            reviews_data = [
+                PullReviewData(review.commit_id, review.state, review.body, review.user.login) for review in reviews_
+            ]
+            res.append(
+                PullRequestData(i.number, i.title, i.base.repo.full_name, i.user.login, i.state, i.merged, reviews_data)
+            )
 
     logger.debug(f"pr list:{res[::-1]}")
     # 逆序 pr 号小的在前

--- a/autotable/autotable_type/github_type.py
+++ b/autotable/autotable_type/github_type.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import TYPE_CHECKING
 
 from autotable.autotable_type.autotable_type import StatusType
-
-if TYPE_CHECKING:
-    from github.PullRequest import PullRequest
+from autotable.storage_model.pull_data import PullRequestData
 
 
 class PrType(Enum):
@@ -26,7 +23,7 @@ class PrType(Enum):
                 raise NotImplementedError(f"pr to autotable StatusType {self} is not supported")
 
 
-def get_pr_type(pr: PullRequest) -> PrType:
+def get_pr_type(pr: PullRequestData) -> PrType:
     match pr.state:
         case "open":
             return PrType.OPEN

--- a/autotable/constant.py
+++ b/autotable/constant.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from github.PullRequest import PullRequest
-    from github.PullRequestReview import PullRequestReview
+    from autotable.storage_model.pull_data import PullRequestData, PullReviewData
 
 APPNAME = "autotable"
 APPAUTHOR = "gouzil"
@@ -13,5 +12,8 @@ CONSOLE_ERROR = "✗"
 
 
 # processor/github_prs cache
-global_error_prs: set[PullRequest] = set()
-global_pr_reviews_cache: dict[int, list[PullRequestReview]] = {}
+_REPO_FULL_NAME = str
+global_error_prs: dict[_REPO_FULL_NAME, set[PullRequestData]] = {}
+global_pr_reviews_cache: dict[_REPO_FULL_NAME, dict[int, list[PullReviewData]]] = {}
+global_pr_reviews_cache: dict[_REPO_FULL_NAME, dict[int, list[PullReviewData]]] = {}
+global_pr_title_index_cache: dict[_REPO_FULL_NAME, dict[int, list[str]]] = {}

--- a/autotable/storage_model/pull_data.py
+++ b/autotable/storage_model/pull_data.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PullRequestData:
+    number: int
+    title: str
+    base_repo_full_name: str
+    user_login: str
+    state: str
+    merged: bool
+    reviews: list[PullReviewData]
+
+    # 原始pygithub数据
+    # NOTE: 这里如果使用原始数据, 还是会导致使用 pygithub 的问题
+    # origin_data: PullRequest
+
+    # 其实只需要计算number就可以了
+    def __hash__(self) -> int:
+        return hash(self.number) + hash(self.title) + hash(self.state)
+
+    def get_reviews(self):
+        return self.reviews
+
+
+@dataclass(frozen=True)
+class PullReviewData:
+    commit_id: str
+    state: str
+    body: str
+    user_login: str
+    # origin_data: PullRequest  # 原始pygithub数据
+
+    def __hash__(self) -> int:
+        return hash(self.commit_id) + hash(self.state)


### PR DESCRIPTION
## reconfiguration
* 为请求后的 GitHub API 添加中间表示层
* 耗时部分迁移至 `get_pr_list (/Users/gouzi/Documents/git/paddle-tools/autoTable/autotable/api/prs.py:14)`
<img width="716" alt="截屏2024-06-25 下午8 04 35" src="https://github.com/gouzil/autoTable/assets/66515297/65366508-53fd-4187-bf9c-cf2bbd7620d3">

## NOTE

* 这个 pr 不会带来任何性能提升

## TODO
* 去除不需要的缓存操作
