### PR TITLE
[Change] 修改 `StatusType` 实现逻辑

### DIFF
--- a/autotable/autotable_type/autotable_type.py
+++ b/autotable/autotable_type/autotable_type.py
@@ -2,9 +2,17 @@ from __future__ import annotations
 
 from enum import Enum
 
+from typing_extensions import Self
+
 
 # 按使用率排序
 class StatusType(Enum):
+    def __new__(cls, value: object) -> Self:
+        obj = object.__new__(cls)
+        obj.index = len(cls.__members__) + 1
+        obj._value_ = value
+        return obj
+
     PENDING = "🔵"  # 待认领
     CLAIMED = "🙋"  # 认领
     REPAIRING = "🚧"  # 正在迁移中, 有pr
@@ -12,40 +20,5 @@ class StatusType(Enum):
     NEXT_STAGE = "🟡"  # 当前阶段不需要人力继续跟进, 下阶段推进
     COMPLETED = "✅"  # 迁移完成
 
-    def __gt__(self, other: StatusType) -> bool:
-        # self > other
-        match (self, other):
-            case (
-                StatusType.REPAIRING
-                | StatusType.CLAIMED
-                | StatusType.COMPLETED
-                | StatusType.PENDING_MERGE
-                | StatusType.NEXT_STAGE,
-                StatusType.PENDING,
-            ):
-                return True
-            case (
-                StatusType.REPAIRING
-                | StatusType.COMPLETED
-                | StatusType.PENDING_MERGE
-                | StatusType.NEXT_STAGE,
-                StatusType.CLAIMED,
-            ):
-                return True
-            case (
-                StatusType.PENDING_MERGE
-                | StatusType.NEXT_STAGE
-                | StatusType.COMPLETED,
-                StatusType.REPAIRING,
-            ):
-                return True
-            case (
-                StatusType.NEXT_STAGE
-                | StatusType.COMPLETED,
-                StatusType.PENDING_MERGE,
-            ):
-                return True
-            case (StatusType.COMPLETED, StatusType.NEXT_STAGE):
-                return True
-            case _:
-                return False
+    def __lt__(self, other: StatusType) -> bool:
+        return self.index < other.index


### PR DESCRIPTION
修改 `StatusType` 实现逻辑，使后面添加的元素`大于`前面添加的元素

``` python
In [52]: s1 = StatusType.PENDING

In [53]: s2 = StatusType.CLAIMED

In [54]: s3 = StatusType.REPAIRING

In [55]: s1 > s2
Out[55]: False

In [56]: s2 > s3
Out[56]: False

In [57]: s3 > s2
Out[57]: True

In [58]: s3 > StatusType("✅")
Out[58]: False

In [59]: s3 < StatusType("✅")
Out[59]: True

In [60]: StatusType("🚧") > StatusType("🙋")
Out[60]: True

In [61]: StatusType("🚧") > StatusType("🔵")
Out[61]: True
```

起因是，统计出现问题 https://github.com/PaddlePaddle/Paddle/issues/65008

![image](https://github.com/user-attachments/assets/cc9394de-e4c2-46bf-8bb3-a2ba0cafdf75)

这个应该是 `完成` 吧？

另外，统计数据的计算也有点问题

![image](https://github.com/user-attachments/assets/4fb1dc36-4ec2-4246-91b5-e670c6d7fe0b)

是否可以

- 任务数量：直接统计任务中 `非删除` 的任务
- 可认领：不统计 `删除` 的任务

p.s. 但是，这个 PR 仍没有解决上述问题 ... ...
