### PR TITLE
👷 add python 3.13 test, and remove 3.10 and 3.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.12", "3.11", "3.10"]
+        python-version: ["3.13", "3.12", "3.11", "3.10"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.12", "3.11", "3.10"]
+        python-version: ["3.13", "3.12"]
     runs-on: ${{ matrix.os }}
     env:
       PYTHONIOENCODING: utf-8


### PR DESCRIPTION
## ci
* 添加 python 3.13 版本的打包和测试
* 移除 3.11 和 3.10 的测试 （主要是等待 ci 的时间太久了）