### PR TITLE
fix: 修复 PR 标题中包含额外方括号时解析失败的问题

### DIFF
--- a/autotable/processor/github_prs.py
+++ b/autotable/processor/github_prs.py
@@ -67,10 +67,6 @@ def update_pr_table(table: Table, title_re: re.Pattern, prs: list[PullRequestDat
 
                 pr_indexs_text = pr_indexs_re.group("task_id")
 
-                # 处理标题中包含额外方括号的情况, 如 [Cleanup][1-10][API] 与 [Cleanup][A-1,A-[2-3]] 不同
-                if "][" in pr_indexs_text:
-                    pr_indexs_text = pr_indexs_text.split("][")[0]
-
                 # 防止一些不是序号的标题
                 try:
                     pr_index_list: list[str] = TitleBase(pr_indexs_text).distribution_parser().mate()

--- a/autotable/processor/github_prs.py
+++ b/autotable/processor/github_prs.py
@@ -67,6 +67,10 @@ def update_pr_table(table: Table, title_re: re.Pattern, prs: list[PullRequestDat
 
                 pr_indexs_text = pr_indexs_re.group("task_id")
 
+                # 处理标题中包含额外方括号的情况, 如 [Cleanup][1-10][API] 与 [Cleanup][A-1,A-[2-3]] 不同
+                if "][" in pr_indexs_text:
+                    pr_indexs_text = pr_indexs_text.split("][")[0]
+
                 # 防止一些不是序号的标题
                 try:
                     pr_index_list: list[str] = TitleBase(pr_indexs_text).distribution_parser().mate()

--- a/autotable/utils/strtool.py
+++ b/autotable/utils/strtool.py
@@ -11,7 +11,7 @@ english_character = r',,.!?;:()<>[]""\'\''
 _translate_table = str.maketrans(chinese_character, english_character)
 
 
-pat_title = re.compile(r"(?P<prefix>[a-zA-Z]+)[^\[]*?((?P<no>(\d+))|(\[(?P<no_start>\d+)-(?P<no_end>\d+)\]))")
+pat_title = re.compile(r"(?P<prefix>[a-zA-Z]+)[^\w]*?((\[(?P<no_start>\d+)-(?P<no_end>\d+)\]?)|(?P<no>(\d+)))")
 
 
 def str_translate(input: str) -> str:

--- a/tests/test_github_title.py
+++ b/tests/test_github_title.py
@@ -37,11 +37,13 @@ def test_mix_title():
     title2 = "1、 2-4、 6"
     title3 = "A-[48-52]"
     title4 = "A-70][A-71"
+    title5 = "A-1,A-[2-3"
 
     assert TitleBase(title1).distribution_parser().mate() == ["1", "2", "3", "4", "6"]
     assert TitleBase(title2).distribution_parser().mate() == ["1", "2", "3", "4", "6"]
     assert TitleBase(title3).distribution_parser().mate() == ["A-48", "A-49", "A-50", "A-51", "A-52"]
     assert TitleBase(title4).distribution_parser().mate() == ["A-70", "A-71"]
+    assert TitleBase(title5).distribution_parser().mate() == ["A-1", "A-2", "A-3"]
 
 
 # 常见的几种错别字测试


### PR DESCRIPTION
pr 标题的正则
```
<!--title_name="\[CodeStyle\]\[Xdoctest\]\[(?P<task_id>[\S\s]+)\]"-->
```

实际 pr 标题
```
[CodeStyle][Xdoctest][8,9-10,315-325][API Compatibility] xxxxxx
```

更新 issue

```
│ /home/runner/.local/lib/python3.12/site-packages/autotable/processor/github_ │
│ title.py:72 in mate                                                          │
│                                                                              │
│    69 │   │   title_content = self.title_content.strip()                     │
│    70 │   │   assert "-" in title_content                                    │
│    71 │   │   (start_index, end_index) = title_content.split("-")            │
│ ❱  72 │   │   return [str(i) for i in range(int(start_index), int(end_index) │
│    73                                                                        │
│    74                                                                        │
│    75 # 单标题                                                               │
│                                                                              │
│ ╭───────────────────────────────── locals ─────────────────────────────────╮ │
│ │     end_index = '325][API Compatibility'                                 │ │
│ │          self = <autotable.processor.github_title.MultipleTitle object   │ │
│ │                 at 0x7ff942a1b740>                                       │ │
│ │   start_index = '315'                                                    │ │
│ │ title_content = '315-325][API Compatibility'                             │ │
│ ╰──────────────────────────────────────────────────────────────────────────╯ │
╰──────────────────────────────────────────────────────────────────────────────╯
ValueError: invalid literal for int() with base 10: '325][API Compatibility'
```